### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ from langchain_ollama import ChatOllama
 ---
 
 
-TODO: Atualizar com informações de como connectar ao e-mail
+TODO: Atualizar com informações de como conectar ao e-mail
 
 ## Licença
 


### PR DESCRIPTION
## Summary
- fix a typo on how to connect to email

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ab0666d9c83308c13f8247eef4d1c