### PR TITLE
Implement local conversation storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ na raiz do projeto. O banco é criado automaticamente na primeira execução.
 Caso queira utilizar outro caminho, altere a constante `DB_PATH` em
 `conversation_storage.py`.
 
+Os títulos das conversas são gerados automaticamente pela IA na primeira
+resposta. Na barra lateral você pode pesquisar pelos títulos para localizar
+conversas antigas com mais facilidade.
+
 ---
 
 ## Observações Técnicas

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Acesse via navegador em [http://localhost:8501](http://localhost:8501)
 
 ---
 
+## Banco de Dados Local
+
+As conversas agora são armazenadas em um arquivo SQLite (`conversations.db`)
+na raiz do projeto. O banco é criado automaticamente na primeira execução.
+Caso queira utilizar outro caminho, altere a constante `DB_PATH` em
+`conversation_storage.py`.
+
+---
+
 ## Observações Técnicas
 
 A classe `ChatOllama` foi migrada para o pacote `langchain-ollama`. Para evitar avisos de depreciação:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Os títulos das conversas são gerados automaticamente pela IA na primeira
 resposta. Na barra lateral você pode pesquisar pelos títulos para localizar
 conversas antigas com mais facilidade.
 
-Também é possível renomear ou excluir conversas existentes pelo menu lateral.
+Para renomear ou excluir uma conversa, clique no botão com três pontinhos ao
+lado do título correspondente na barra lateral.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Os títulos das conversas são gerados automaticamente pela IA na primeira
 resposta. Na barra lateral você pode pesquisar pelos títulos para localizar
 conversas antigas com mais facilidade.
 
+Também é possível renomear ou excluir conversas existentes pelo menu lateral.
+
 ---
 
 ## Observações Técnicas

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ Os títulos das conversas são gerados automaticamente pela IA na primeira
 resposta. Na barra lateral você pode pesquisar pelos títulos para localizar
 conversas antigas com mais facilidade.
 
-Para renomear ou excluir uma conversa, clique no botão com três pontinhos ao
-lado do título correspondente na barra lateral.
+Para renomear ou excluir uma conversa, clique nos três pontinhos **dentro** do
+botão da conversa na barra lateral. Um menu suspenso será exibido com as opções
+"Editar" (renomear) e "Excluir".
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ Os títulos das conversas são gerados automaticamente pela IA na primeira
 resposta. Na barra lateral você pode pesquisar pelos títulos para localizar
 conversas antigas com mais facilidade.
 
-Para renomear ou excluir uma conversa, clique nos três pontinhos **dentro** do
-botão da conversa na barra lateral. Um menu suspenso será exibido com as opções
-"Editar" (renomear) e "Excluir".
+Para renomear ou excluir uma conversa, utilize o botão de três pontinhos (⋯)
+alinhado à direita do título da conversa na barra lateral. Após clicar nesse
+botão, um pequeno menu é exibido com as opções **Renomear** e **Excluir**. Ao
+escolher "Renomear", aparece um campo de texto para definir o novo título; já
+"Excluir" requer uma confirmação antes de remover o chat da lista.
 
 ---
 

--- a/agente_graph.py
+++ b/agente_graph.py
@@ -69,6 +69,16 @@ def count_tokens(message, model_name="gpt-4"):
 def generate_thread_id():
     return str(uuid.uuid4())
 
+
+def generate_conversation_title(messages):
+    """Use the LLM to generate a short title for a conversation."""
+    prompt = (
+        "Resuma a conversa abaixo em um titulo curto (maximo 5 palavras).\n\n"
+    )
+    text = "\n".join(m["content"] for m in messages[-2:])
+    resp = chat.invoke([HumanMessage(content=prompt + text)])
+    return resp.content.strip()
+
 def get_current_datetime(args=None) -> datetime:
     current_date = datetime.now()
     print(f"📅 Data e hora atual: {current_date}")

--- a/app_graph.py
+++ b/app_graph.py
@@ -37,33 +37,26 @@ with st.sidebar:
         if not search or search.lower() in (title or "").lower()
     ]
     for tid, title in convs:
-        cols = st.columns([0.85, 0.15])
+        cols = st.columns([0.9, 0.1])
         label = title if title else tid[:8]
-        if cols[0].button(label, key=f"conv-{tid}"):
+        if cols[0].button(label, key=f"conv-{tid}", use_container_width=True):
             st.session_state.messages = load_conversation(tid)
             st.session_state.uid = tid
             st.session_state.title = title
             st.rerun()
-        if cols[1].button("\u22ee", key=f"menu-btn-{tid}"):
-            current = st.session_state.get("menu_open")
-            st.session_state.menu_open = None if current == tid else tid
-            st.rerun()
-        if st.session_state.get("menu_open") == tid:
-            new_title = st.text_input("Novo título", key=f"rename-{tid}")
-            b1, b2 = st.columns(2)
-            if b1.button("Renomear", key=f"btn-rename-{tid}") and new_title:
+        with cols[1].popover("\u22ee", key=f"menu-{tid}"):
+            new_title = st.text_input("Novo título", value=title or "", key=f"rename-{tid}")
+            if st.button("Renomear", key=f"btn-rename-{tid}") and new_title:
                 rename_conversation(tid, new_title)
                 if st.session_state.uid == tid:
                     st.session_state.title = new_title
-                st.session_state.menu_open = None
                 st.rerun()
-            if b2.button("Excluir", key=f"btn-del-{tid}"):
+            if st.button("Excluir", key=f"btn-del-{tid}"):
                 delete_conversation(tid)
                 if st.session_state.uid == tid:
                     st.session_state.messages = []
                     st.session_state.uid = generate_thread_id()
                     st.session_state.title = None
-                st.session_state.menu_open = None
                 st.rerun()
 
     st.divider()

--- a/app_graph.py
+++ b/app_graph.py
@@ -59,7 +59,8 @@ with st.sidebar:
 
     for tid, title in convs:
         st.markdown("<div class='conv-row'>", unsafe_allow_html=True)
-        row = st.columns([0.88, 0.12], gap="0")
+        # use a small gap since Streamlit only accepts "small", "medium" or "large"
+        row = st.columns([0.88, 0.12], gap="small")
         label = title if title else tid[:8]
         if row[0].button(label, key=f"conv-{tid}", use_container_width=True):
             st.session_state.messages = load_conversation(tid)

--- a/app_graph.py
+++ b/app_graph.py
@@ -44,7 +44,7 @@ with st.sidebar:
             st.session_state.uid = tid
             st.session_state.title = title
             st.rerun()
-        with cols[1].popover("\u22ee", key=f"menu-{tid}"):
+        with cols[1].popover("\u22ee"):
             new_title = st.text_input("Novo título", value=title or "", key=f"rename-{tid}")
             if st.button("Renomear", key=f"btn-rename-{tid}") and new_title:
                 rename_conversation(tid, new_title)

--- a/conversation_storage.py
+++ b/conversation_storage.py
@@ -1,0 +1,48 @@
+import json
+import os
+from datetime import datetime
+
+FILE_PATH = "conversations.json"
+
+
+def _load_all():
+    if os.path.exists(FILE_PATH):
+        try:
+            with open(FILE_PATH, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _save_all(data):
+    with open(FILE_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def save_conversation(thread_id: str, messages: list):
+    """Save messages of a conversation."""
+    data = _load_all()
+    data[thread_id] = {
+        "messages": messages,
+        "updated_at": datetime.now().isoformat()
+    }
+    _save_all(data)
+
+
+def load_conversation(thread_id: str) -> list:
+    """Load messages for a specific conversation."""
+    data = _load_all()
+    conv = data.get(thread_id)
+    if conv:
+        return conv.get("messages", [])
+    return []
+
+
+def list_conversations() -> list:
+    """Return list of (thread_id, updated_at)."""
+    data = _load_all()
+    return [
+        (tid, info.get("updated_at"))
+        for tid, info in data.items()
+    ]

--- a/conversation_storage.py
+++ b/conversation_storage.py
@@ -1,48 +1,86 @@
+import sqlite3
 import json
-import os
 from datetime import datetime
+from contextlib import closing
+from typing import List, Tuple
 
-FILE_PATH = "conversations.json"
-
-
-def _load_all():
-    if os.path.exists(FILE_PATH):
-        try:
-            with open(FILE_PATH, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except json.JSONDecodeError:
-            return {}
-    return {}
+DB_PATH = "conversations.db"
 
 
-def _save_all(data):
-    with open(FILE_PATH, "w", encoding="utf-8") as f:
-        json.dump(data, f)
+def _get_conn(db_path: str = DB_PATH):
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    _init_db(conn)
+    return conn
 
 
-def save_conversation(thread_id: str, messages: list):
-    """Save messages of a conversation."""
-    data = _load_all()
-    data[thread_id] = {
-        "messages": messages,
-        "updated_at": datetime.now().isoformat()
-    }
-    _save_all(data)
+def _init_db(conn: sqlite3.Connection):
+    with conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS conversations (
+            thread_id TEXT PRIMARY KEY,
+            updated_at TEXT
+        )"""
+        )
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            thread_id TEXT,
+            role TEXT,
+            content TEXT,
+            sources TEXT,
+            FOREIGN KEY(thread_id) REFERENCES conversations(thread_id)
+        )"""
+        )
 
 
-def load_conversation(thread_id: str) -> list:
-    """Load messages for a specific conversation."""
-    data = _load_all()
-    conv = data.get(thread_id)
-    if conv:
-        return conv.get("messages", [])
-    return []
 
 
-def list_conversations() -> list:
-    """Return list of (thread_id, updated_at)."""
-    data = _load_all()
-    return [
-        (tid, info.get("updated_at"))
-        for tid, info in data.items()
-    ]
+def save_conversation(thread_id: str, messages: List[dict], db_path: str = DB_PATH):
+    """Persist messages of a conversation."""
+    now = datetime.now().isoformat()
+    with closing(_get_conn(db_path)) as conn, conn:
+        conn.execute(
+            "INSERT INTO conversations(thread_id, updated_at) VALUES(?, ?) "
+            "ON CONFLICT(thread_id) DO UPDATE SET updated_at=excluded.updated_at",
+            (thread_id, now),
+        )
+        conn.execute("DELETE FROM messages WHERE thread_id=?", (thread_id,))
+        for msg in messages:
+            conn.execute(
+                "INSERT INTO messages(thread_id, role, content, sources) VALUES(?, ?, ?, ?)",
+                (
+                    thread_id,
+                    msg.get("role"),
+                    msg.get("content"),
+                    json.dumps(msg.get("sources")) if msg.get("sources") is not None else None,
+                ),
+            )
+
+
+def load_conversation(thread_id: str, db_path: str = DB_PATH) -> List[dict]:
+    """Retrieve messages for a conversation."""
+    with closing(_get_conn(db_path)) as conn:
+        rows = conn.execute(
+            "SELECT role, content, sources FROM messages WHERE thread_id=? ORDER BY id",
+            (thread_id,),
+        ).fetchall()
+    result = []
+    for row in rows:
+        data = {
+            "role": row["role"],
+            "content": row["content"],
+        }
+        if row["sources"]:
+            data["sources"] = json.loads(row["sources"])
+        result.append(data)
+    return result
+
+
+def list_conversations(db_path: str = DB_PATH) -> List[Tuple[str, str]]:
+    """List available conversations as (thread_id, updated_at)."""
+    with closing(_get_conn(db_path)) as conn:
+        rows = conn.execute(
+            "SELECT thread_id, updated_at FROM conversations ORDER BY updated_at DESC"
+        ).fetchall()
+    return [(row["thread_id"], row["updated_at"]) for row in rows]

--- a/conversation_storage.py
+++ b/conversation_storage.py
@@ -101,3 +101,19 @@ def list_conversations(db_path: str = DB_PATH) -> List[Tuple[str, str]]:
             "SELECT thread_id, title FROM conversations ORDER BY updated_at DESC"
         ).fetchall()
     return [(row["thread_id"], row["title"] or "") for row in rows]
+
+
+def delete_conversation(thread_id: str, db_path: str = DB_PATH) -> None:
+    """Remove a conversation and its messages."""
+    with closing(_get_conn(db_path)) as conn, conn:
+        conn.execute("DELETE FROM messages WHERE thread_id=?", (thread_id,))
+        conn.execute("DELETE FROM conversations WHERE thread_id=?", (thread_id,))
+
+
+def rename_conversation(thread_id: str, new_title: str, db_path: str = DB_PATH) -> None:
+    """Change the title of a stored conversation."""
+    with closing(_get_conn(db_path)) as conn, conn:
+        conn.execute(
+            "UPDATE conversations SET title=?, updated_at=? WHERE thread_id=?",
+            (new_title, datetime.now().isoformat(), thread_id),
+        )

--- a/tests/test_conversation_storage.py
+++ b/tests/test_conversation_storage.py
@@ -7,6 +7,8 @@ from conversation_storage import (
     save_conversation,
     load_conversation,
     list_conversations,
+    delete_conversation,
+    rename_conversation,
 )
 
 
@@ -21,4 +23,18 @@ def test_save_and_load(tmp_path, monkeypatch):
 
     convs = list_conversations(db_path=str(path))
     assert convs and convs[0] == (tid, "titulo")
+
+
+def test_rename_and_delete(tmp_path):
+    path = tmp_path / "conv.db"
+    tid = "t1"
+    msgs = [{"role": "assistant", "content": "hi"}]
+    save_conversation(tid, msgs, title="old", db_path=str(path))
+
+    rename_conversation(tid, "novo", db_path=str(path))
+    convs = list_conversations(db_path=str(path))
+    assert convs == [(tid, "novo")]
+
+    delete_conversation(tid, db_path=str(path))
+    assert list_conversations(db_path=str(path)) == []
 

--- a/tests/test_conversation_storage.py
+++ b/tests/test_conversation_storage.py
@@ -7,20 +7,18 @@ from conversation_storage import (
     save_conversation,
     load_conversation,
     list_conversations,
-    FILE_PATH,
 )
 
 
 def test_save_and_load(tmp_path, monkeypatch):
-    path = tmp_path / "conv.json"
-    monkeypatch.setattr("conversation_storage.FILE_PATH", str(path))
+    path = tmp_path / "conv.db"
 
     tid = "thread1"
     messages = [{"role": "user", "content": "oi"}]
 
-    save_conversation(tid, messages)
-    assert load_conversation(tid) == messages
+    save_conversation(tid, messages, db_path=str(path))
+    assert load_conversation(tid, db_path=str(path)) == messages
 
-    convs = list_conversations()
+    convs = list_conversations(db_path=str(path))
     assert convs and convs[0][0] == tid
 

--- a/tests/test_conversation_storage.py
+++ b/tests/test_conversation_storage.py
@@ -16,9 +16,9 @@ def test_save_and_load(tmp_path, monkeypatch):
     tid = "thread1"
     messages = [{"role": "user", "content": "oi"}]
 
-    save_conversation(tid, messages, db_path=str(path))
+    save_conversation(tid, messages, title="titulo", db_path=str(path))
     assert load_conversation(tid, db_path=str(path)) == messages
 
     convs = list_conversations(db_path=str(path))
-    assert convs and convs[0][0] == tid
+    assert convs and convs[0] == (tid, "titulo")
 

--- a/tests/test_conversation_storage.py
+++ b/tests/test_conversation_storage.py
@@ -1,0 +1,26 @@
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from conversation_storage import (
+    save_conversation,
+    load_conversation,
+    list_conversations,
+    FILE_PATH,
+)
+
+
+def test_save_and_load(tmp_path, monkeypatch):
+    path = tmp_path / "conv.json"
+    monkeypatch.setattr("conversation_storage.FILE_PATH", str(path))
+
+    tid = "thread1"
+    messages = [{"role": "user", "content": "oi"}]
+
+    save_conversation(tid, messages)
+    assert load_conversation(tid) == messages
+
+    convs = list_conversations()
+    assert convs and convs[0][0] == tid
+


### PR DESCRIPTION
## Summary
- add simple JSON-based conversation storage
- integrate conversation persistence and sidebar management into Streamlit UI
- test conversation storage utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab83116488330a95386cb1292a54a