### PR TITLE
Expand conversation search

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ Caso queira utilizar outro caminho, altere a constante `DB_PATH` em
 `conversation_storage.py`.
 
 Os títulos das conversas são gerados automaticamente pela IA na primeira
-resposta. Na barra lateral você pode pesquisar pelos títulos para localizar
-conversas antigas com mais facilidade.
+resposta. Na barra lateral agora é possível pesquisar tanto pelos títulos
+quanto pelo conteúdo das mensagens para localizar conversas antigas com
+mais facilidade.
 
 Para renomear ou excluir uma conversa, utilize o botão de três pontinhos (⋯)
 alinhado à direita do título da conversa na barra lateral. Após clicar nesse

--- a/app_graph.py
+++ b/app_graph.py
@@ -10,6 +10,7 @@ from conversation_storage import (
     list_conversations,
     delete_conversation,
     rename_conversation,
+    search_conversations,
 )
 import asyncio
 
@@ -35,11 +36,10 @@ if "title" not in st.session_state:
 with st.sidebar:
     st.header("Conversas")
     search = st.text_input("Buscar")
-    convs = [
-        (tid, title)
-        for tid, title in list_conversations()
-        if not search or search.lower() in (title or "").lower()
-    ]
+    if search:
+        convs = search_conversations(search)
+    else:
+        convs = list_conversations()
     st.markdown(
         """
         <style>

--- a/tests/test_conversation_storage.py
+++ b/tests/test_conversation_storage.py
@@ -9,6 +9,7 @@ from conversation_storage import (
     list_conversations,
     delete_conversation,
     rename_conversation,
+    search_conversations,
 )
 
 
@@ -37,4 +38,20 @@ def test_rename_and_delete(tmp_path):
 
     delete_conversation(tid, db_path=str(path))
     assert list_conversations(db_path=str(path)) == []
+
+
+def test_search_conversations(tmp_path):
+    path = tmp_path / "conv.db"
+    tid1 = "c1"
+    tid2 = "c2"
+    save_conversation(tid1, [{"role": "user", "content": "foo bar"}], title="saudações", db_path=str(path))
+    save_conversation(tid2, [{"role": "assistant", "content": "outra coisa"}], title="outro", db_path=str(path))
+
+    # search by title
+    res = search_conversations("sauda", db_path=str(path))
+    assert (tid1, "saudações") in res and (tid2, "outro") not in res
+
+    # search by message content
+    res = search_conversations("outra", db_path=str(path))
+    assert (tid2, "outro") in res and (tid1, "saudações") not in res
 


### PR DESCRIPTION
## Summary
- add a new `search_conversations` helper
- use this helper in the Streamlit sidebar
- update documentation about the search feature
- test conversation search by title and by message content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bae6af7d08330a85d657f32482e6e